### PR TITLE
entire test suite should be run and pass prior to submitting a PR

### DIFF
--- a/protocol/git.md
+++ b/protocol/git.md
@@ -65,7 +65,8 @@ Share your branch.
 
     git flow feature publish <feature-name>
 
-Submit a [GitHub pull request].
+Submit a [GitHub pull request] after confirming the **entire test suite** passes
+locally.
 
 Currently, upon PR creation a JIRA trigger will automatically move the ticket
 status to *Code Review Requested* and assign the ticket


### PR DESCRIPTION
Following some issues recently with PRs, I want to explicitly note this requirement for creating Pull Requests.

@VivianChu @hweng @dt-ucsd @lsitu I don't believe this is controversial enough to discuss at length, but please review this and comment with a :+1: when you have. Then I'll ask someone to merge. Thanks.
