### PR TITLE
git force push use case

### DIFF
--- a/protocol/git.md
+++ b/protocol/git.md
@@ -57,7 +57,7 @@ cohesive commits with good messages. You can also do this after the pull request
 is created, if you receive feedback that requires additional commits.
 
 See the git documentation for [rebase] or this tutorial on [squashing commits
-with rebase]
+with rebase].
 
     git rebase -i origin/develop
 
@@ -66,6 +66,10 @@ Share your branch.
     git flow feature publish <feature-name>
 
 Submit a [GitHub pull request].
+
+If you have already submitted a pull request and need to rebase to squash additional commits you will likely need to force push your squashed commit.
+
+  `git push -f`
 
 Currently, upon PR creation a JIRA trigger will automatically move the ticket
 status to *Code Review Requested* and assign the ticket


### PR DESCRIPTION
When a Pull Requests already exists and additional commits are made and/or need to be squashed to follow the style guide, a git force push will likely be required to update the remote feature branch after rebasing+squashing locally.
