### PR TITLE
updating documentation to reflect team PR review

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Since this repository covers best practice recommendations for the entire team,
 no PR will be merged until the entire team gives a :thumbsup:.
 
 *Note: For all other project repositories, follow the standard workflow outlined
-in [git](protocol/git.md)*
+in [git](protocol/git.md) and [code review](protocol/code_review.md)*
 
 ## License
 Distributed under [CC0 1.0 Universal](LICENSE)

--- a/protocol/code_review.md
+++ b/protocol/code_review.md
@@ -34,26 +34,33 @@ Having Your Code Reviewed
 * Extract some changes and refactorings into future tickets/stories.
 * Link to the code review from the JIRA ticket/story. ("Ready for review:
   https://github.com/organization/project/pull/1")
+* Send a comment in the PR to the `@ucsdlib/developers` group, asking for
+  feedback.
 * Push commits based on earlier rounds of feedback as isolated commits to the branch. Do not squash until the branch is ready to merge. Reviewers should be able to read individual updates based on their earlier feedback.
 * Seek to understand the reviewer's perspective.
 * Try to respond to every comment.
-* Wait to merge the branch until Bamboo plan tells you the test suite is green in the branch.
-* Merge once you feel confident in the code and its impact on the project.
 
 Reviewing Code
 --------------
 
+Pull Requests should be reviewed, and signed off, by at least two members of the development team. This is to facilitate shared knowledge across the group about updates to the entire codebase for a project, as well as ensuring we follow current best practices as consistently as possible.
+
+Note that you can @mention our entire group at once by using `@ucsdlib/developers` in your
+comments.
+
 Understand why the code is necessary (bug, user experience, refactoring). Then:
 
 * Communicate which ideas you feel strongly about and those you don't.
-* Identify ways to simplify the code while still solving the problem.
-* If discussions turn too philosophical or academic, move the discussion offline
-  to a regular Friday afternoon technique discussion. In the meantime, let the
-  author make the final decision on alternative implementations.
+* Identify ways to potentially refactor and simplify the code while still solving the problem.
+* If discussions turn too philosophical or academic, bring up the discussion in
+  the next Development Team Meeting. In the meantime, let the author make the final decision on alternative implementations.
 * Offer alternative implementations, but assume the author already considered
   them. ("What do you think about using a custom validator here?")
 * Seek to understand the author's perspective.
+* Wait to merge the branch until Bamboo plan tells you the test suite is green in the branch.
+* Merge once you feel confident in the code and its impact on the project.
 * Sign off on the pull request with a :thumbsup: or "Ready to merge" comment.
+* The last team member to sign off should merge the pull request.
 
 Style Comments
 --------------

--- a/protocol/git.md
+++ b/protocol/git.md
@@ -74,13 +74,13 @@ If you have already submitted a pull request and need to rebase to squash additi
 
 Currently, upon PR creation a JIRA trigger will automatically move the ticket
 status to *Code Review Requested* and assign the ticket
-to the project lead developer to perform [Code Review](code_review.md)
+to the project lead developer role to perform [Code Review](code_review.md)
+However, it is actually the responsibility of the team to review the PR. JIRA is
+not able to assign responsibility of a workflow state to a group. Be sure to
+send a comment in the PR to the `@ucsdlib/developers` group asking for review.
 
 *Please do not submit PRs on the last day of a Sprint. This does not give the
   team adequate time for the review process prior to creating a release.*
-
-*NOTE: We will likely change this process in the near future to include the
-entire team in the Code Review process*
 
 [good commit message]: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 [GitHub pull request]: https://help.github.com/articles/using-pull-requests/
@@ -91,14 +91,14 @@ http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html
 Review Code
 -----------
 
-A team member other than the author reviews the pull request. They follow
+At least two team members other than the author reviews the pull request. They follow
 [Code Review](code_review.md) guidelines to avoid
-miscommunication.
+miscommunication. See [Code Review](code_review.md) for more information.
 
 They make comments and ask questions directly on lines of code in the GitHub
 web interface or in the JIRA ticket if non-developer feedback is needed.
 
-When satisfied, the PR is merged and the JIRA workflow will automatically mark
+When satisfied, the PR is merged by the last developer to sign off and the JIRA workflow will automatically mark
 the ticket as Resolved.
 
 Delete the feature branch following the PR merge.


### PR DESCRIPTION
@ucsdlib/developers - per our various conversations, please find a proposed update to our PR review process that removes me as the only/primary PR reviewer. Thank you for the feedback on this that has led to this proposed update.

This process would be first used in the damspas repo, since it is the main project that has overlap for the entire team. In the future, we can look to expanding this to additional projects as well. 

Feedback, questions, and other ideas welcome. And as usual, we won't merge this until the entire team signs off with a 👍 
