### PR TITLE
rename tto to oic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A repository for organizing style guides, templates, tools, and techniques for t
   * [Git](protocol/git.md)
   * [Release Management](protocol/release_management.md)
 * [Templates](templates/README.md)
-  * [UCSD TTO Copyright Disclosure Form](http://invent.ucsd.edu/invent/researchers/reporting-new-innovation/copyright-disclosure-form/)
+  * [UC San Diego Copyright Disclosure Form](http://invent.ucsd.edu/invent/researchers/reporting-new-innovation/copyright-disclosure-form/)
   * [Code Climate](templates/.codeclimate.yml)
   * [Copyright](templates/UC_Copyright_Notice.txt)
 * [Best Practices](best-practices/README.md)

--- a/templates/README.md
+++ b/templates/README.md
@@ -2,9 +2,9 @@
 
 The following templates should be used in the creation of new projects.
 
-Prior to creating the new project repository in Github, the [Copyright Disclosure Form](http://invent.ucsd.edu/invent/researchers/reporting-new-innovation/copyright-disclosure-form/) must be filled out and signed by the entire development team, and then emailed to the UCSD Technology Transfer Office.
+Prior to creating the new project repository in Github, the [Copyright Disclosure Form](http://invent.ucsd.edu/invent/researchers/reporting-new-innovation/copyright-disclosure-form/) must be filled out and signed by the entire development team, and then emailed to the Office of Innovation and Commercialization (OIC).
 
-Once the copyright disclosure form has been turned into TTO, proceed with
+Once the copyright disclosure form has been turned into OIC, proceed with
 creating the new public repository in the [UCSD Library Organization](https://github.com/ucsdlib/) using the following templates.
 
 In the case of the UC Copyright Notice and License they should be used

--- a/templates/UC_Copyright_Notice.txt
+++ b/templates/UC_Copyright_Notice.txt
@@ -1,4 +1,4 @@
-This software is Copyright © 2012-2013 The Regents of the University of
+This software is Copyright © 2015-2016 The Regents of the University of
 California. All Rights Reserved.
 
 Permission to copy, modify, and distribute this software and its documentation


### PR DESCRIPTION
The Technology Transfer Office has been renamed to the Office of Innovation and Commercialization. This update references accordingly.
