### PR TITLE
prefer --force-with-lease to -force

### DIFF
--- a/protocol/git.md
+++ b/protocol/git.md
@@ -70,7 +70,7 @@ locally.
 
 If you have already submitted a pull request and need to rebase to squash additional commits you will likely need to force push your squashed commit.
 
-  `git push -f`
+  `git push --force-with-lease origin <feature-name>`
 
 Currently, upon PR creation a JIRA trigger will automatically move the ticket
 status to *Code Review Requested* and assign the ticket


### PR DESCRIPTION
This will hopefully address the issues we've had with using the `-f` or `-force` command when interactive rebasing to squash commits in PRs.

See git docs:

```
--force-with-lease=<refname>:<expect>

    Usually, "git push" refuses to update a remote ref that is not an ancestor of the local ref used to overwrite it.

    This option overrides this restriction if the current value of the remote ref is the expected value. "git push" fails otherwise.

    Imagine that you have to rebase what you have already published. You will have to bypass the "must fast-forward" rule in order to replace the history you originally published with the rebased history. If somebody else built on top of your original history while you are rebasing, the tip of the branch at the remote may advance with her commit, and blindly pushing with --force will lose her work.

    This option allows you to say that you expect the history you are updating is what you rebased and want to replace. If the remote ref still points at the commit you specified, you can be sure that no other people did anything to the ref. It is like taking a "lease" on the ref without explicitly locking it, and the remote ref is updated only if the "lease" is still valid.

    --force-with-lease alone, without specifying the details, will protect all remote refs that are going to be updated by requiring their current value to be the same as the remote-tracking branch we have for them.

    --force-with-lease=<refname>, without specifying the expected value, will protect the named ref (alone), if it is going to be updated, by requiring its current value to be the same as the remote-tracking branch we have for it.

    --force-with-lease=<refname>:<expect> will protect the named ref (alone), if it is going to be updated, by requiring its current value to be the same as the specified value <expect> (which is allowed to be different from the remote-tracking branch we have for the refname, or we do not even have to have such a remote-tracking branch when this form is used).

    Note that all forms other than --force-with-lease=<refname>:<expect> that specifies the expected current value of the ref explicitly are still experimental and their semantics may change as we gain experience with this feature.

    "--no-force-with-lease" will cancel all the previous --force-with-lease on the command line.
```
